### PR TITLE
Change BASE_URL to https by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var fetch = require('node-fetch');
-var BASE_URL = "http://api.pexels.com/v1/";
+var BASE_URL = "https://api.pexels.com/v1/";
 var DIRECTORY = {
     SEARCH_URL: BASE_URL + "search",
     POPULAR_URL: BASE_URL + "popular"


### PR DESCRIPTION
For projects served on *http* this shouldn't be an issue, but for projects served on *https* some browsers block mixed content and the library will not work.